### PR TITLE
Pre-empt local 'registration' test failure due to 'bad' suite directories

### DIFF
--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc suite registration
-# WARNING: bad directories under ~/cylc-run can screw this test.
 
 . "$(dirname "$0")/test_header"
 set_test_number 7
@@ -46,7 +45,16 @@ contains_ok "${TEST_NAME_BASE}-print.stdout" <<__OUT__
 ${SUITE_NAME} | the quick brown fox | ${TEST_DIR}/${SUITE_NAME}
 __OUT__
 
-cmp_ok "${TEST_NAME_BASE}-print.stderr" <'/dev/null'
+# Filter out errors from 'bad' suites in the 'cylc-run' directory
+NONSPECIFIC_ERR2='\[Errno 2\] No such file or directory:'
+SPECIFIC_ERR2="$NONSPECIFIC_ERR2 '$HOME/cylc-run/$SUITE_NAME/suite.rc'"
+ERR2_COUNT=$(grep -c "$SPECIFIC_ERR2" "${TEST_NAME_BASE}-print.stderr")
+if [ "$ERR2_COUNT" -eq "0" ]; then
+    grep -v -s "$NONSPECIFIC_ERR2" "${TEST_NAME_BASE}-print.stderr" > "${TEST_NAME_BASE}-print-filtered.stderr"
+    cmp_ok "${TEST_NAME_BASE}-print-filtered.stderr" <'/dev/null'
+else
+    fail "${TEST_NAME_BASE}-print.stderr"
+fi
 
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/registration/01-no-skip1.t
+++ b/tests/registration/01-no-skip1.t
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc print doesn't skip special names at root level,
-# WARNING: bad directories under ~/cylc-run can screw this test.
 
 # e.g. "~/cylc-run/work"
 . "$(dirname "$0")/test_header"
@@ -39,7 +38,17 @@ run_ok "${TEST_NAME_BASE}-print" cylc print
 contains_ok "${TEST_NAME_BASE}-print.stdout" <<__OUT__
 work | the quick brown fox | ${TEST_DIR}/${SUITE_NAME}
 __OUT__
-cmp_ok "${TEST_NAME_BASE}-print.stderr" <'/dev/null'
+
+# Filter out errors from 'bad' suites in the 'cylc-run' directory
+NONSPECIFIC_ERR2='\[Errno 2\] No such file or directory:'
+SPECIFIC_ERR2="$NONSPECIFIC_ERR2 '$HOME/cylc-run/$SUITE_NAME/suite.rc'"
+ERR2_COUNT=$(grep -c "$SPECIFIC_ERR2" "${TEST_NAME_BASE}-print.stderr")
+if [ "$ERR2_COUNT" -eq "0" ]; then
+    grep -v -s "$NONSPECIFIC_ERR2" "${TEST_NAME_BASE}-print.stderr" > "${TEST_NAME_BASE}-print-filtered.stderr"
+    cmp_ok "${TEST_NAME_BASE}-print-filtered.stderr" <'/dev/null'
+else
+    fail "${TEST_NAME_BASE}-print.stderr"
+fi
 
 rm -f "${RUND}/work"
 purge_suite "${SUITE_NAME}"


### PR DESCRIPTION
Prevents tests under ``tests/registration`` failing locally due to 'bad' suite directories in ``$HOME/cylc-run``, instead of simply warning that this might cause issue.