### PR TITLE
config: add experimental configuration section

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -375,6 +375,40 @@ with Conf(
                The default time zone is now ``Z`` instead of the local time of
                the first workflow start.
         ''')
+        with Conf('experimental', desc='''
+            Activate experimental features.
+
+            These are preview features which will become the default in future
+            releases.
+
+            .. versionadded:: 8.6.0
+        '''):
+            Conf('all', VDR.V_BOOLEAN, False, desc='''
+                Activate all experimental features.
+
+                Encouraged for canary testing.
+
+                .. versionadded:: 8.6.0
+            ''')
+            Conf('expire triggers', VDR.V_BOOLEAN, False, desc='''
+                This reimplements "suicide triggers" as "expire triggers".
+
+                * When the condition is met, the task will generate the
+                  ``expired`` output rather than being removed from the pool.
+                * The triggered task's
+                  `flow.cylc[runtime][<namespace>]completion condition`
+                  will be automatically modified so that expiry completes the
+                  task's outputs.
+                * This should be functionally equivalent to "suicide triggers"
+                  in that the triggered task will not run.
+                * However, the triggered task will now be left in the
+                  ``expired`` state making it clearer in the GUI/logs that
+                  the task has been triggered in this way.
+                * It is possible to trigger other tasks off of this ``expired``
+                  output for more advanced failure recovery.
+
+                .. versionadded:: 8.6.0
+            ''')
 
         with Conf(   # noqa: SIM117 (keep same format)
             'main loop',

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -394,7 +394,7 @@ with Conf(
                 This reimplements "suicide triggers" as "expire triggers".
 
                 * When the condition is met, the task will generate the
-                  ``expired`` output rather than being removed from the pool.
+                  ``expired`` output rather than just being removed from the pool.
                 * The triggered task's
                   `flow.cylc[runtime][<namespace>]completion condition`
                   will be automatically modified so that expiry completes the

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -394,7 +394,7 @@ with Conf(
                 This reimplements "suicide triggers" as "expire triggers".
 
                 * When the condition is met, the task will generate the
-                  ``expired`` output rather than just being removed from the pool.
+                  ``expired`` output rather than just being removed.
                 * The triggered task's
                   `flow.cylc[runtime][<namespace>]completion condition`
                   will be automatically modified so that expiry completes the

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -34,6 +34,7 @@ from pathlib import Path
 import re
 from textwrap import wrap
 import traceback
+from types import SimpleNamespace
 from typing import (
     Any, Callable, Dict, List, Mapping, Optional, Set, TYPE_CHECKING, Tuple,
     Union, Iterable
@@ -421,6 +422,7 @@ class WorkflowConfig:
         self.mem_log("config.py: after get(sparse=False)")
 
         # These 2 must be called before call to init_cyclers(self.cfg):
+        self.set_exerimental_features()
         self.process_utc_mode()
         self.process_cycle_point_tz()
 
@@ -570,6 +572,14 @@ class WorkflowConfig:
         self.mem_log("config.py: end init config")
 
         skip_mode_validate(self.taskdefs)
+
+    def set_exerimental_features(self):
+        all_ = self.cfg['scheduler']['experimental']['all']
+        self.experimental = SimpleNamespace(**{
+            key.replace(' ', '_'): value or all_
+            for key, value in self.cfg['scheduler']['experimental'].items()
+            if key != 'all'
+        })
 
     @staticmethod
     def _warn_if_queues_have_implicit_tasks(
@@ -2261,7 +2271,8 @@ class WorkflowConfig:
             parser = GraphParser(
                 family_map,
                 self.parameters,
-                task_output_opt=task_output_opt
+                task_output_opt=task_output_opt,
+                expire_triggers=self.experimental.expire_triggers,
             )
             parser.parse_graph(graph)
             task_output_opt.update(parser.task_output_opt)

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -422,7 +422,7 @@ class WorkflowConfig:
         self.mem_log("config.py: after get(sparse=False)")
 
         # These 2 must be called before call to init_cyclers(self.cfg):
-        self.set_exerimental_features()
+        self.set_experimental_features()
         self.process_utc_mode()
         self.process_cycle_point_tz()
 
@@ -573,7 +573,7 @@ class WorkflowConfig:
 
         skip_mode_validate(self.taskdefs)
 
-    def set_exerimental_features(self):
+    def set_experimental_features(self):
         all_ = self.cfg['scheduler']['experimental']['all']
         self.experimental = SimpleNamespace(**{
             key.replace(' ', '_'): value or all_

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -19,11 +19,11 @@ import re
 import contextlib
 
 from typing import (
-    Set,
     Dict,
     List,
-    Tuple,
     Optional,
+    Set,
+    Tuple,
     Union
 )
 
@@ -264,7 +264,8 @@ class GraphParser:
         family_map: Optional[Dict[str, List[str]]] = None,
         parameters: Optional[Dict] = None,
         task_output_opt:
-            Optional[Dict[Tuple[str, str], Tuple[bool, bool, bool]]] = None
+            Optional[Dict[Tuple[str, str], Tuple[bool, bool, bool]]] = None,
+        expire_triggers: bool = False,
     ) -> None:
         """Initialize the graph string parser.
 
@@ -283,6 +284,7 @@ class GraphParser:
         self.triggers: Dict = {}
         self.original: Dict = {}
         self.workflow_state_polling_tasks: Dict = {}
+        self.expire_triggers = expire_triggers
 
         # Record task outputs as optional or required:
         #   {(name, output): (is_optional, is_member)}
@@ -744,7 +746,7 @@ class GraphParser:
         self.original.setdefault(name, {})
         self.original[name][expr] = orig_expr
 
-        if suicide:
+        if suicide and self.expire_triggers:
             # Make expiry optional for suicide triggered tasks.
             self._set_output_opt(name, TASK_OUTPUT_EXPIRED, True, False, False)
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1532,9 +1532,13 @@ class TaskPool:
                         suicide.append(t)
 
         for c_task in suicide:
-            self.task_queue_mgr.remove_task(c_task)
-            self.task_events_mgr.process_message(
-                c_task, logging.WARNING, TASK_OUTPUT_EXPIRED)
+            if self.config.experimental.expire_triggers:
+                self.task_queue_mgr.remove_task(c_task)
+                self.task_events_mgr.process_message(
+                    c_task, logging.WARNING, TASK_OUTPUT_EXPIRED
+                )
+            else:
+                self.remove(c_task, self.__class__.SUICIDE_MSG)
 
         if suicide:
             # Update DB now in case of very quick respawn attempt.

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2039,7 +2039,7 @@ async def test_remove_active_task(
     )
 
 
-async def test_remove_by_suicide(
+async def test_remove_by_expire_trigger(
     flow,
     scheduler,
     start,
@@ -2052,6 +2052,11 @@ async def test_remove_by_suicide(
     * Removing a task manually (cylc remove) should work the same.
     """
     id_ = flow({
+        'scheduler': {
+            'experimental': {
+                'expire triggers': 'True',
+            }
+        },
         'scheduling': {
             'graph': {
                 'R1': '''
@@ -2093,6 +2098,64 @@ async def test_remove_by_suicide(
         # and bring 1/b back again by triggering it again
         log.clear()
         schd.pool.force_trigger_tasks(['1/b'], ['1'])
+        assert log_filter(regex='1/b.*added to the n=0 window',)
+
+
+async def test_remove_by_suicide(
+    flow,
+    scheduler,
+    start,
+    log_filter
+):
+    """Test task removal by suicide trigger.
+
+    * Suicide triggers should remove tasks from the pool.
+    * It should be possible to bring them back by manually triggering them.
+    * Removing a task manually (cylc remove) should work the same.
+    """
+    id_ = flow({
+        'scheduling': {
+            'graph': {
+                'R1': '''
+                    a? & b
+                    a:failed? => !b
+                '''
+            },
+        }
+    })
+    schd: 'Scheduler' = scheduler(id_)
+    async with start(schd, level=logging.DEBUG) as log:
+        # it should start up with 1/a and 1/b
+        assert schd.pool.get_task_ids() == {"1/a", "1/b"}
+        a = schd.pool.get_task(IntegerPoint("1"), "a")
+
+        # mark 1/a as failed and ensure 1/b is removed by suicide trigger
+        schd.pool.spawn_on_output(a, TASK_OUTPUT_FAILED)
+        assert log_filter(
+            regex="1/b.*removed from the n=0 window: suicide trigger"
+        )
+        assert schd.pool.get_task_ids() == {"1/a"}
+
+        # ensure that we are able to bring 1/b back by triggering it
+        log.clear()
+        await commands.run_cmd(
+            commands.force_trigger_tasks(schd, ['1/b'], ['1']))
+        assert log_filter(
+            regex='1/b.*added to the n=0 window',
+        )
+
+        # remove 1/b by request (cylc remove)
+        await commands.run_cmd(
+            commands.remove_tasks(schd, ['1/b'], [])
+        )
+        assert log_filter(
+            regex='1/b.*removed from the n=0 window: request',
+        )
+
+        # ensure that we are able to bring 1/b back by triggering it
+        log.clear()
+        await commands.run_cmd(
+            commands.force_trigger_tasks(schd, ['1/b'], ['1']))
         assert log_filter(regex='1/b.*added to the n=0 window',)
 
 


### PR DESCRIPTION
MO operations are targetted at 8.6.0.

Workflow testing has completed with 8.4.x, there is no scope for further testing and no resource to do it with.

This feature is a functional change, though it "aught" not to cause problems, it's unclear what interactions might be discovered when run in anger. Cylc has such a large feature set that unexpected interactions often occur, an unexpected bug could be very damaging for us if introduced at this stage.

Any issues would likely be detected post go-live at which point minor version changes are not permitted.

Happy for this feature to go in, just need to de-risk operations.